### PR TITLE
Fix issue with values not being quoted

### DIFF
--- a/src/BulkInsert.php
+++ b/src/BulkInsert.php
@@ -197,8 +197,8 @@ class BulkInsert
         }
         $values = [];
         foreach ($this->rows as $row) {
-            array_map([$this->adapter->quote(), 'value'], $row);
-            $values[] = '(' . implode(', ', $row) . ')';
+            $quoted = array_map([$this->adapter->quote(), 'value'], $row);
+            $values[] = '(' . implode(', ', $quoted) . ')';
         }
         $values = implode(', ', $values);
 

--- a/tests/BulkInsertTest.php
+++ b/tests/BulkInsertTest.php
@@ -39,6 +39,41 @@ class BulkInsertTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider fetchSqlQuotesDataProvider
+     * @param mixed $value
+     * @param string $expected
+     */
+    public function testFetchSqlQuotes($value, $expected)
+    {
+        $table = 'test_table';
+        $insertFields = ['field'];
+        $updateFields = ['field'];
+        $inserter = new BulkInsert($this->adapter, $table, $insertFields, $updateFields);
+
+        $inserter->add([$value]);
+        $actual = $inserter->fetchSql();
+
+        $expectedSql = "VALUES ({$expected})";
+
+        $this->assertContains($expectedSql, $actual);
+    }
+
+    public function fetchSqlQuotesDataProvider()
+    {
+        return [
+            ['string', '`string`'],
+            ['a1', '`a1`'],
+            ['1a', '`1a`'],
+            [172, '172'],
+            ['172', '172'],
+            [172.16, '172.16'],
+            ['172.16', '172.16'],
+            ['172.16.255.255', '`172.16.255.255`'],
+            ['2017-03-18 00:00:00', '`2017-03-18 00:00:00`'],
+        ];
+    }
+
+    /**
      * @dataProvider fetchSqlIgnoreUpdateDataProvider
      * @param bool $ignore
      * @param bool $update


### PR DESCRIPTION
Values given to `add()` are not being correctly quoted when building the SQL.

This basically means that BulkInsert doesn't work with any string values, and is a security risk.

This should be an immediate patch release.