### PR TITLE
Refactor tests to not rely on internals

### DIFF
--- a/tests/BigResultTest.php
+++ b/tests/BigResultTest.php
@@ -23,25 +23,20 @@ class BigResultTest extends \PHPUnit_Framework_TestCase
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
 
-        $this->adapter = $this->getMockBuilder(Adapter::class)->getMock();
-        $this->adapter->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($pdoStatement));
-        parent::setUp();
-    }
+        $this->adapter = $this->createMock(Adapter::class);
+        $this->adapter->method('prepare')
+            ->willReturn($pdoStatement);
 
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->adapter = null;
+        parent::setUp();
     }
 
     public function testQueryIsSetupForLongQueryTime()
     {
         $queryTime = 123;
-        $this->adapter->expects($this->once())
+        $this->adapter->expects(static::once())
             ->method('query')
-            ->with($this->stringContains("long_query_time=$queryTime"));
+            ->with(static::stringContains("long_query_time=$queryTime"));
+
         (new BigResult($this->adapter, ['long_query_time' => $queryTime]))
             ->query('SELECT');
     }
@@ -49,24 +44,27 @@ class BigResultTest extends \PHPUnit_Framework_TestCase
     public function testQueryIsSetupForWriteTimeout()
     {
         $writeTimeout = 123;
-        $this->adapter->expects($this->once())
+        $this->adapter->expects(static::once())
             ->method('query')
-            ->with($this->stringContains("net_write_timeout=$writeTimeout"));
+            ->with(static::stringContains("net_write_timeout=$writeTimeout"));
+
         (new BigResult($this->adapter, ['net_write_timeout' => $writeTimeout]))
             ->query('SELECT');
     }
 
     public function testQueryDisablesBuffering()
     {
-        $this->adapter->expects($this->once())
+        $this->adapter->expects(static::once())
             ->method('disableBuffering');
+
         (new BigResult($this->adapter))->query('SELECT');
     }
 
     public function testQueryReturnsStatement()
     {
         $bigResult = (new BigResult($this->adapter));
-        $this->assertInstanceOf(\PDOStatement::class, $bigResult->query('SELECT'));
+
+        static::assertInstanceOf(\PDOStatement::class, $bigResult->query('SELECT'));
     }
 
     public function testCheckForInspectedRowLimitOnSuccess()
@@ -76,11 +74,12 @@ class BigResultTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$this->adapter])
             ->setMethods(['getInspectedRows'])
             ->getMock();
-        $bigResult->expects($this->any())
-            ->method('getInspectedRows')
-            ->will($this->returnValue(5));
-        $this->adapter->expects($this->once())
+        $bigResult->method('getInspectedRows')
+            ->willReturn(5);
+
+        $this->adapter->expects(static::once())
             ->method('query');
+
         $bigResult->query('SELECT', [], 10);
     }
 
@@ -94,14 +93,14 @@ class BigResultTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$this->adapter])
             ->setMethods(['getInspectedRows'])
             ->getMock();
-        $bigResult->expects($this->any())
-            ->method('getInspectedRows')
-            ->will($this->returnValue(10));
+        $bigResult->method('getInspectedRows')
+            ->willReturn(10);
+
         $bigResult->query('SELECT', [], 5);
     }
 
     public function testStaticExecuteReturnsStatement()
     {
-        $this->assertInstanceOf(\PDOStatement::class, BigResult::execute($this->adapter, 'SELECT'));
+        static::assertInstanceOf(\PDOStatement::class, BigResult::execute($this->adapter, 'SELECT'));
     }
 }

--- a/tests/BulkInsertTest.php
+++ b/tests/BulkInsertTest.php
@@ -123,14 +123,11 @@ class BulkInsertTest extends \PHPUnit_Framework_TestCase
 
     public function testAddCallsWriteWhenExceedsBatchSize()
     {
-        /** @var \Phlib\DbHelper\BulkInsert|\PHPUnit_Framework_MockObject_MockObject $inserter */
-        $inserter = $this->getMockBuilder(BulkInsert::class)
-            ->setConstructorArgs([$this->adapter, 'table_name', ['field1'], [], ['batchSize' => 1]])
-            ->setMethods(['write'])
-            ->getMock();
+        $inserter = new BulkInsert($this->adapter, 'table_name', ['field1'], [], ['batchSize' => 1]);
 
-        $inserter->expects(static::once())
-            ->method('write');
+        $this->adapter->expects(static::once())
+            ->method('execute')
+            ->willReturn(1);
 
         $inserter->add(['field1' => 'foo']);
     }

--- a/tests/QueryPlannerTest.php
+++ b/tests/QueryPlannerTest.php
@@ -22,26 +22,20 @@ class QueryPlannerTest extends \PHPUnit_Framework_TestCase
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
 
-        $this->adapter = $this->getMockBuilder(Adapter::class)->getMock();
-        $this->adapter->expects($this->any())
-            ->method('prepare')
-            ->will($this->returnValue($pdoStatement));
+        $this->adapter = $this->createMock(Adapter::class);
+        $this->adapter->method('prepare')
+            ->willReturn($pdoStatement);
         parent::setUp();
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-        $this->adapter = null;
     }
 
     public function testGetPlanDoesExplain()
     {
         $pdoStatement = $this->createMock(\PDOStatement::class);
-        $this->adapter->expects($this->once())
+        $this->adapter->expects(static::once())
             ->method('query')
-            ->with($this->stringContains('EXPLAIN', true))
-            ->will($this->returnValue($pdoStatement));
+            ->with(static::stringContains('EXPLAIN', true))
+            ->willReturn($pdoStatement);
+
         (new QueryPlanner($this->adapter, 'SELECT'))->getPlan();
     }
 
@@ -61,12 +55,11 @@ class QueryPlannerTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$this->adapter, 'SELECT'])
             ->setMethods(['getPlan'])
             ->getMock();
-        $planner->expects($this->any())
-            ->method('getPlan')
-            ->will($this->returnValue($plan));
+        $planner->method('getPlan')
+            ->willReturn($plan);
 
         $expected = $row1 * $row2 * $row3;
-        $this->assertEquals($expected, $planner->getNumberOfRowsInspected());
+        static::assertEquals($expected, $planner->getNumberOfRowsInspected());
     }
 
     public function testGetNumberOfRowsInspectedDoesNotExceedMaxInt()
@@ -83,10 +76,9 @@ class QueryPlannerTest extends \PHPUnit_Framework_TestCase
             ->setConstructorArgs([$this->adapter, 'SELECT'])
             ->setMethods(['getPlan'])
             ->getMock();
-        $planner->expects($this->any())
-            ->method('getPlan')
-            ->will($this->returnValue($plan));
+        $planner->method('getPlan')
+            ->willReturn($plan);
 
-        $this->assertInternalType('integer', $planner->getNumberOfRowsInspected());
+        static::assertInternalType('integer', $planner->getNumberOfRowsInspected());
     }
 }

--- a/tests/QueryPlannerTest.php
+++ b/tests/QueryPlannerTest.php
@@ -20,11 +20,8 @@ class QueryPlannerTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $pdoStatement = $this->createMock(\PDOStatement::class);
-
         $this->adapter = $this->createMock(Adapter::class);
-        $this->adapter->method('prepare')
-            ->willReturn($pdoStatement);
+
         parent::setUp();
     }
 
@@ -50,13 +47,17 @@ class QueryPlannerTest extends \PHPUnit_Framework_TestCase
             ['rows' => $row3]
         ];
 
-        /** @var QueryPlanner|\PHPUnit_Framework_MockObject_MockObject $planner */
-        $planner = $this->getMockBuilder(QueryPlanner::class)
-            ->setConstructorArgs([$this->adapter, 'SELECT'])
-            ->setMethods(['getPlan'])
-            ->getMock();
-        $planner->method('getPlan')
+        $pdoStatement = $this->createMock(\PDOStatement::class);
+
+        $this->adapter->expects(static::once())
+            ->method('query')
+            ->willReturn($pdoStatement);
+
+        $pdoStatement->expects(static::once())
+            ->method('fetchAll')
             ->willReturn($plan);
+
+        $planner = new QueryPlanner($this->adapter, 'SELECT');
 
         $expected = $row1 * $row2 * $row3;
         static::assertEquals($expected, $planner->getNumberOfRowsInspected());
@@ -71,13 +72,17 @@ class QueryPlannerTest extends \PHPUnit_Framework_TestCase
             ['rows' => $row2]
         ];
 
-        /** @var QueryPlanner|\PHPUnit_Framework_MockObject_MockObject $planner */
-        $planner = $this->getMockBuilder(QueryPlanner::class)
-            ->setConstructorArgs([$this->adapter, 'SELECT'])
-            ->setMethods(['getPlan'])
-            ->getMock();
-        $planner->method('getPlan')
+        $pdoStatement = $this->createMock(\PDOStatement::class);
+
+        $this->adapter->expects(static::once())
+            ->method('query')
+            ->willReturn($pdoStatement);
+
+        $pdoStatement->expects(static::once())
+            ->method('fetchAll')
             ->willReturn($plan);
+
+        $planner = new QueryPlanner($this->adapter, 'SELECT');
 
         static::assertInternalType('integer', $planner->getNumberOfRowsInspected());
     }


### PR DESCRIPTION
- Update unit test style to PHPUnit v5
- Allow QueryPlanner to be injected into BigResult for testing
  - Allows BigResult tests to pass in mock QueryPlanner, rather than having to create a partial mock of the tested class.
  - Injection of QueryPlanner is not expected to be used in regular implementations of this package.