### PR TITLE
Make `BulkInsert::fetchSql()` private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- *BulkInsert*: **BC Break**: Private visibility for `fetchSql()` method. This
+  shouldn't be used in regular implementations, as the SQL is used directly by
+  `write()`.
 
 ## [1.0.2] - 2021-10-24
 ### Fixed

--- a/src/BulkInsert.php
+++ b/src/BulkInsert.php
@@ -184,16 +184,12 @@ class BulkInsert
     }
 
     /**
-     * Constructs the bulk insert statement based on the rows added so far. If
-     * no rows have been added then it returns false.
-     *
-     * @return string|false
+     * @return string
      */
-    public function fetchSql()
+    private function fetchSql()
     {
-        if (count($this->rows) == 0) {
-            return false;
-        }
+        // No need to check for non-zero row count.
+        // This method is only called from write(), which has its own check for zero rows.
         $values = [];
         foreach ($this->rows as $row) {
             $quoted = array_map([$this->adapter->quote(), 'value'], $row);


### PR DESCRIPTION
Allows the method signature to be changed to a single type.
This method should not be used or overridden by implementations.