### PR TITLE
Quote BulkInsert table and field identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- **BC break**: *BulkInsert*: Automatically quote identifiers for the table and fields.
+  Implementations must remove any manual identifier quotes that they were
+  previously forced to include manually.
 
 ## [2.0.0] - 2021-10-25
 ### Added

--- a/src/BulkInsert.php
+++ b/src/BulkInsert.php
@@ -79,9 +79,11 @@ class BulkInsert
             $values = [];
             foreach ($fields as $key => $value) {
                 if (is_int($key)) {
-                    $values[] = "{$value} = VALUES({$value})";
+                    $quotedField = $this->adapter->quote()->identifier($value);
+                    $values[] = "{$quotedField} = VALUES({$quotedField})";
                 } else {
-                    $values[] = $this->adapter->quote()->into("{$key} = ?", $value);
+                    $quotedField = $this->adapter->quote()->identifier($key);
+                    $values[] = $this->adapter->quote()->into("{$quotedField} = ?", $value);
                 }
             }
             $this->updateFields = $values;
@@ -157,8 +159,9 @@ class BulkInsert
         } elseif ($this->insertIgnore === true) {
             $insert[] = 'IGNORE';
         }
-        $insert[] = "INTO {$this->table}";
-        $insert[] = '(' . implode(', ', $this->insertFields) . ') VALUES';
+        $insert[] = 'INTO ' . $this->adapter->quote()->identifier($this->table);
+        $quotedInsert = array_map([$this->adapter->quote(), 'identifier'], $this->insertFields);
+        $insert[] = '(' . implode(', ', $quotedInsert) . ') VALUES';
 
         return trim(implode(' ', $insert) . " {$values} {$update}");
     }

--- a/tests/BulkInsertTest.php
+++ b/tests/BulkInsertTest.php
@@ -91,12 +91,14 @@ class BulkInsertTest extends TestCase
             rand(),
         ];
 
+        $insert = [];
         $duplicate = [];
         foreach ($fields as $field) {
-            $duplicate[] = $field . " = VALUES({$field})";
+            $insert[] = "`{$field}`";
+            $duplicate[] = "`{$field}` = VALUES(`{$field}`)";
         }
-        $expectedSql = "INSERT INTO {$table} (" .
-            implode(', ', $fields) . ') VALUES (' .
+        $expectedSql = "INSERT INTO `{$table}` (" .
+            implode(', ', $insert) . ') VALUES (' .
             implode(', ', $values1) . '), (' .
             implode(', ', $values2) . ') ' .
             'ON DUPLICATE KEY UPDATE ' .
@@ -134,12 +136,16 @@ class BulkInsertTest extends TestCase
             rand(),
         ];
 
-        $expectedSql = "INSERT INTO {$table} (" .
-            implode(', ', $fields) . ') VALUES (' .
+        $insert = [];
+        foreach ($fields as $field) {
+            $insert[] = "`{$field}`";
+        }
+        $expectedSql = "INSERT INTO `{$table}` (" .
+            implode(', ', $insert) . ') VALUES (' .
             implode(', ', $values) . ') ' .
             'ON DUPLICATE KEY UPDATE ' .
-            $fields[0] . " = VALUES({$fields[0]}), " .
-            $fields[1] . " = {$expected}";
+            "`{$fields[0]}` = VALUES(`{$fields[0]}`), " .
+            "`{$fields[1]}` = {$expected}";
 
         $inserter = new BulkInsert($this->adapter, $table, $fields, $updateFields);
 


### PR DESCRIPTION
BC break because of edge cases where implementations have been forced to add their own quoting, this must be removed.